### PR TITLE
Remove DevContainer from Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,6 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: devcontainers
-    directory: /
-    schedule:
-      interval: monthly
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
BTW @shenanigansd, this repo doesn't have a DevContainer config.